### PR TITLE
Add remote-controlled presentation feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node presentation-server.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -62,7 +63,8 @@
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "socket.io-client": "^4.7.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",
@@ -81,6 +83,7 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "socket.io": "^4.7.5"
   }
 }

--- a/presentation-server.js
+++ b/presentation-server.js
@@ -1,0 +1,33 @@
+const http = require('http');
+const { Server } = require('socket.io');
+
+const server = http.createServer();
+const io = new Server(server, {
+  cors: { origin: '*' }
+});
+
+let currentSlide = 0;
+
+io.on('connection', (socket) => {
+  socket.emit('slideUpdate', currentSlide);
+
+  socket.on('nextSlide', () => {
+    currentSlide++;
+    io.emit('slideUpdate', currentSlide);
+  });
+
+  socket.on('prevSlide', () => {
+    currentSlide = Math.max(0, currentSlide - 1);
+    io.emit('slideUpdate', currentSlide);
+  });
+
+  socket.on('changeSlide', (idx) => {
+    currentSlide = idx;
+    io.emit('slideUpdate', currentSlide);
+  });
+});
+
+const PORT = process.env.PORT || 3001;
+server.listen(PORT, () => {
+  console.log(`Presentation server listening on ${PORT}`);
+});

--- a/presentation-server.js
+++ b/presentation-server.js
@@ -1,5 +1,5 @@
-const http = require('http');
-const { Server } = require('socket.io');
+import http from 'http';
+import { Server } from 'socket.io';
 
 const server = http.createServer();
 const io = new Server(server, {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,8 @@ import ProjectsPage from "./pages/ProjectsPage";
 import ContactPage from "./pages/ContactPage";
 import BlogPage from "./pages/BlogPage";
 import BlogPostPage from "./pages/BlogPostPage";
+import PresentationPage from "./pages/PresentationPage";
+import PresentationRemote from "./pages/PresentationRemote";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -30,6 +32,8 @@ const App = () => (
           <Route path="/contact" element={<ContactPage />} />
           <Route path="/blog" element={<BlogPage />} />
           <Route path="/blog/:slug" element={<BlogPostPage />} />
+          <Route path="/presentation" element={<PresentationPage />} />
+          <Route path="/remote" element={<PresentationRemote />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/data/slides.ts
+++ b/src/data/slides.ts
@@ -1,0 +1,5 @@
+export const slides = [
+  { title: 'Introdução', content: 'Bem-vindo à minha apresentação!' },
+  { title: 'Sobre', content: 'Aqui você pode colocar informações importantes.' },
+  { title: 'Obrigado', content: 'Obrigado por assistir.' }
+];

--- a/src/pages/PresentationPage.tsx
+++ b/src/pages/PresentationPage.tsx
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import { io } from 'socket.io-client';
+import { slides } from '@/data/slides';
+
+const socket = io('http://localhost:3001');
+
+const PresentationPage = () => {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    socket.on('slideUpdate', setIndex);
+    return () => {
+      socket.off('slideUpdate', setIndex);
+    };
+  }, []);
+
+  const slide = slides[index] || { title: 'Fim', content: '' };
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center p-8 text-center">
+      <h1 className="mb-4 text-4xl font-bold">{slide.title}</h1>
+      <p className="text-xl">{slide.content}</p>
+    </div>
+  );
+};
+
+export default PresentationPage;

--- a/src/pages/PresentationRemote.tsx
+++ b/src/pages/PresentationRemote.tsx
@@ -1,0 +1,13 @@
+import { io } from 'socket.io-client';
+import { Button } from '@/components/ui/button';
+
+const socket = io('http://localhost:3001');
+
+const PresentationRemote = () => (
+  <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-8">
+    <Button onClick={() => socket.emit('prevSlide')}>Anterior</Button>
+    <Button onClick={() => socket.emit('nextSlide')}>Próximo</Button>
+  </div>
+);
+
+export default PresentationRemote;


### PR DESCRIPTION
## Summary
- add slide data and a Socket.io server
- create PresentationPage and PresentationRemote pages
- expose routes for presentation and remote control
- register new server script in package.json

## Testing
- `npx eslint src/pages/PresentationPage.tsx src/pages/PresentationRemote.tsx src/data/slides.ts`
- `npm run lint` *(fails: 20 problems from existing code)*

------
https://chatgpt.com/codex/tasks/task_b_684a26c949b8832abfb0493c592b6a61